### PR TITLE
Fix typo in description

### DIFF
--- a/src/deployment-guides/tanzu-standard-on-vmc-aws.md
+++ b/src/deployment-guides/tanzu-standard-on-vmc-aws.md
@@ -1,5 +1,5 @@
 # Deploy Tanzu for Kubernetes Operations on VMware Cloud on AWS
-This document provides step-by-step instructions for deploying and Tanzu Kubernetes Operations on VMware Cloud on AWS. 
+This document provides step-by-step instructions for deploying Tanzu Kubernetes Operations on VMware Cloud on AWS. 
 
 The scope of the document is limited to providing the deployment steps based on the reference design in [VMware Tanzu Standard on VMware Cloud on AWS Reference Design](../reference-designs/tko-on-vmc-aws.md)
 


### PR DESCRIPTION
Remove extraneous "and" in the document description.

Signed-off-by: Craig Tracey <craigtracey@gmail.com>