### PR TITLE
Address typos in tko-on-vsphere deployment guide

### DIFF
--- a/src/deployment-guides/tko-on-vsphere.md
+++ b/src/deployment-guides/tko-on-vsphere.md
@@ -363,10 +363,9 @@ Below procedure provides steps to configure bootstrap virtual machines based on 
 
 * Execute  below commands to install TKG CLI, Kubectl CLIs and Carvel tools  
 
-<!-- /* cSpell:disable */ -->    
 ```bash
 # Install required packages  
-dnf install tar zip unzip wget -y
+tdnf install tar zip unzip wget -y
 
 # Install TKG CLI
 tar -xvf tanzu-cli-bundle-linux-amd64.tar
@@ -401,7 +400,7 @@ chmod ugo+x kbld-linux-amd64-v0.30.0+vmware.1 && mv ./kbld-linux-amd64-v0.30.0+v
 # impkg
 cd ./cli
 gunzip imgpkg-linux-amd64-v0.10.0+vmware.1.gz
-chmod ugo+x imgpkg-linux-amd64-v0.10.0+vmware.1 && mv ./imgpkg-linux-amd64-v0.10.0+vmware.1/usr/local/bin/imgpkg
+chmod ugo+x imgpkg-linux-amd64-v0.10.0+vmware.1 && mv ./imgpkg-linux-amd64-v0.10.0+vmware.1 /usr/local/bin/imgpkg
 ```
 <!-- /* cSpell:enable */ -->
 
@@ -418,11 +417,9 @@ chmod ugo+x imgpkg-linux-amd64-v0.10.0+vmware.1 && mv ./imgpkg-linux-amd64-v0.10
 wget https://github.com/mikefarah/yq/releases/download/v4.13.4/yq_linux_amd64.tar.gz  
 tar -xvf yq_linux_amd64.tar.gz && mv yq_linux_amd64 /usr/local/bin/yq
 ```
-<!-- /* cSpell:enable */ -->
 
 * Photon OS has docker installed by default, use below commands to start the service and enable it to start at system boot.
 
-<!-- /* cSpell:disable */ -->
 ```bash
 # Check Docker service status  
 systemctl status docker   
@@ -433,18 +430,15 @@ systemctl start docker   
 # To start Docker Service at boot  
 systemctl enable docker
 ```
-<!-- /* cSpell:enable */ -->
 
 * Ensure that the bootstrap machine is using [cgroup v1](https://man7.org/linux/man-pages/man7/cgroups.7.html) by running below command  
 
-<!-- /* cSpell:disable */ -->
 ```bash
-dockerinfo | grep -i cgroup  
+docker info | grep -i cgroup  
 
 # You should see the following output:
 #  Cgroup Driver: cgroupfs
 ```
-<!-- /* cSpell:enable */ -->
 
 
 * Create an SSH Key Pair: This is required for Tanzu CLI to connect to vSphere from the bootstrap machine. The public key part of the generated key will be passed during the TKG management cluster deployment.    
@@ -512,13 +506,11 @@ For the bootstrap machine to pull images from private image repository, the `TKG
 
 If your local image repository uses self-signed certificates, also add `TKG_CUSTOM_IMAGE_REPOSITORY_CA_CERTIFICATE` to the global cluster configuration file. Provide the CA certificate in base64encoded format by executing `base64 -w 0 your-ca.crt`.  
 
- <!-- /* cSpell:disable */ -->
 ```bash
 TKG_CUSTOM_IMAGE_REPOSITORY: custom-image-repository.io/yourproject
 TKG_CUSTOM_IMAGE_REPOSITORY_SKIP_TLS_VERIFY: false
 TKG_CUSTOM_IMAGE_REPOSITORY_CA_CERTIFICATE: LS0t\[...\]tLS0tLQ==
 ```
- <!-- /* cSpell:enable */ -->
 
 
 Deploying a management cluster may be accomplished by utilizing the Installer interface:
@@ -668,7 +660,6 @@ You can also specify standard sizes for the control plane and worker node VMs, o
 Below is a sample file with the minimum required configurations. To know about all configuration file variables, see the Tanzu CLI Configuration File Variable Reference[https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.4/vmware-tanzu-kubernetes-grid-14/GUID-tanzu-config-reference.html](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.4/vmware-tanzu-kubernetes-grid-14/GUID-tanzu-config-reference.html)  
 Modify the parameters as per your requirements.  
 
-<!-- /* cSpell:disable */ -->
 ```bash
 CLUSTER_CIDR: 100.96.0.0/11
 SERVICE_CIDR: 100.64.0.0/13
@@ -698,7 +689,6 @@ CONTROLPLANE_SIZE: small/medium/large/extra-large
 WORKER_SIZE: small/medium/large/extra-large
 WORKER_MACHINE_COUNT: <# of worker nodes to be deployed>
 ```
-<!-- /* cSpell:enable */ -->
 
 Key configuration considerations while creating  Shared Service cluster config file
 
@@ -716,7 +706,6 @@ Key configuration considerations while creating  Shared Service cluster config 
 
 Following is an example of a modified Tanzu Kubernetes Grid shared service configuration file:
 
-<!-- /* cSpell:disable */ -->
 ```bash
 CLUSTER_CIDR: 100.96.0.0/11
 SERVICE_CIDR: 100.64.0.0/13
@@ -746,7 +735,6 @@ CONTROLPLANE_SIZE: large
 WORKER_SIZE: extra-large
 WORKER_MACHINE_COUNT: 1
 ```
-<!-- /* cSpell:enable */ -->
 
 Upon preparing the cluster configuration file, execute the following command to initiate the cluster deployment:
 
@@ -797,7 +785,6 @@ As per the architecture, workload clusters make use of a separate SE group (Serv
 Below is a sample file with the minimum required configurations to create a TKG workload cluster. To know about all configuration file variables, see the Tanzu CLI Configuration File Variable Reference[https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.4/vmware-tanzu-kubernetes-grid-14/GUID-tanzu-config-reference.html](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.4/vmware-tanzu-kubernetes-grid-14/GUID-tanzu-config-reference.html)  
 Modify the parameters as per your requirements.
 
-<!-- /* cSpell:disable */ -->
 ```bash
 CLUSTER_CIDR: 100.96.0.0/11
 SERVICE_CIDR: 100.64.0.0/13
@@ -827,7 +814,6 @@ CONTROLPLANE_SIZE: small/medium/large/extra-large
 WORKER_SIZE: small/medium/large/extra-large
 WORKER_MACHINE_COUNT: # of worker nodes to be deployed>
 ```
-<!-- /* cSpell:enable */ -->
 
 Key config considerations while creating  Workload cluster config file
 
@@ -847,7 +833,6 @@ Key config considerations while creating  Workload cluster config file
 
 Below is the modified TKG shared service config file  
 
-<!-- /* cSpell:disable */ -->
 ```bash
 CLUSTER_CIDR: 100.96.0.0/11  
 SERVICE_CIDR: 100.64.0.0/13
@@ -877,7 +862,6 @@ CONTROLPLANE_SIZE: large
 WORKER_SIZE: extra-large  
 WORKER_MACHINE_COUNT: 3
 ```
-<!-- /* cSpell:enable */ -->
 
 Upon preparing the cluster configuration file, execute the following command to initiate the cluster deployment:
 
@@ -900,7 +884,6 @@ A separate SE group (Service Engine Group 2) and VIP Network (TKG Workload VIP/
 
 Below is the format of the AKODeploymentConfig yaml file.  
 
-<!-- /* cSpell:disable */ -->
 ```yaml
 apiVersion: networking.tkg.tanzu.vmware.com/v1alpha1
 kind: AKODeploymentConfig  
@@ -933,7 +916,6 @@ spec:
   disableIngressClass: true
   serviceEngineGroup: <SERVICE ENGINE NAME>
 ```
-<!-- /* cSpell:enable */ -->
 
 Below is the sample AKODeploymentConfig with sample values in place, as per the below configuration, TKG management cluster will deploy AKO pod on any workload cluster that matches the label `type=workloadset01` and the AKO configuration will be as below
 
@@ -941,7 +923,6 @@ Below is the sample AKODeploymentConfig with sample values in place, as per the 
 * service engine Group: `tanzu-wkld-segroup-01`
 * VIP/data network: tkg_workload_vip_pg
 
-<!-- /* cSpell:disable */ -->
 ```yaml
 apiVersion: networking.tkg.tanzu.vmware.com/v1alpha1kind: AKODeploymentConfig  
 metadata:  
@@ -959,7 +940,6 @@ metadata:
      pullPolicy: IfNotPresentrepository: projects.registry.vmware.com/tkg/akoversion: v1.3.2_vmware.1ingress:  
      defaultIngressController: falsedisableIngressClass: trueserviceEngineGroup: tanzu-wkld-segroup-01
 ```
-<!-- /* cSpell:enable */ -->
 
 
 Once you have the AKO configuration file ready, use kubectl command to set the context to TKG management cluster and use below command to list the available `AKODeploymentConfig`.  
@@ -1042,7 +1022,6 @@ Contour is required for the harbor, and Prometheus and Grafana packages
 
 2.  Create below configuration file named `contour-data-values.yaml`  
 
-<!-- /* cSpell:disable */ -->    
 ```yaml
 ---
 infrastructure_provider: vspherenamespace: tanzu-system-ingresscontour:  
@@ -1059,7 +1038,6 @@ certificates:
 duration: 8760h  
 renewBefore: 360h  
 ```
-<!-- /* cSpell:enable */ -->
 
 3.  Using below command to capture the available Contour version  
 


### PR DESCRIPTION
Corrects three command typos in the vsphere deployment guide. Also
cleans out (now) unecessary cspell annotations on command blocks.

Signed-off-by: Craig Tracey <craigtracey@gmail.com>

Closes #81 