### PR TITLE
Make local testing easy

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+# Markdown Project Tool
+_md-cli/
+output/
+.venv/
+
+tests/
+!.github/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,21 @@
 # Contributing to tanzu-validated-solutions
 
-The tanzu-validated-solutions project team welcomes contributions from the community. Before you start working with tanzu-validated-solutions, please
-read our [Developer Certificate of Origin](https://cla.vmware.com/dco). All contributions to this repository must be
-signed as described on that page. Your signature certifies that you wrote the patch or have the right to pass it on
-as an open-source patch.
+The tanzu-validated-solutions project team welcomes contributions from the
+community. Before you start working with tanzu-validated-solutions, please read
+our [Developer Certificate of Origin](https://cla.vmware.com/dco). All
+contributions to this repository must be signed as described on that page using
+the `Signed-Off-By` commit header. Your signature certifies that you wrote the
+patch or have the right to pass it on as an open-source patch.
+
+Use `git commit --signoff` to sign your commits. We recommend adding an alias
+to your Git configuration file at `$HOME/.gitconfig` to make this easier. To
+create an alias (like `git cs` instead of `git commit --signoff`), add this
+block of code to your `$HOME/.gitconfig` file:
+
+```gitconfig
+[alias]
+  cs = commit --signoff
+```
 
 ## Contribution Flow
 
@@ -12,6 +24,7 @@ This is a rough outline of what a contributor's workflow looks like:
 - Create a topic branch from where you want to base your work
 - Make commits of logical units
 - Make sure your commit messages are in the proper format (see below)
+- Test locally
 - Push your changes to a topic branch in your fork of the repository
 - Submit a pull request
 
@@ -21,6 +34,7 @@ Example:
 git remote add upstream https://github.com/vmware/@(project).git
 git checkout -b my-new-feature main
 git commit -a
+docker-compose run --rm tests
 git push origin my-new-feature
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,15 @@ block of code to your `$HOME/.gitconfig` file:
   cs = commit --signoff
 ```
 
+> ✅ GitHub will not allow you to sign off commits with a personal email
+> if you have chosen to [keep your commits
+> private](https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-github-user-account/managing-email-preferences/setting-your-commit-email-address).
+> To work-around this without disabling this feature, add a working email address
+> that you are okay to use for signing off to commit but
+> **do not add it to your profile.**
+>
+> If you wish to sign off com
+
 ## Contribution Flow
 
 This is a rough outline of what a contributor's workflow looks like:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM golang:1.17.7-buster
+
+# Needed in order to update since apk update configures tzdata.
+RUN ln -sf /usr/share/zoneinfo/UTC > /etc/localtime
+
+RUN apt -y update
+
+# Install the Docker client and Git (needed by 'go install')
+# Note that you'll need to make sure that /var/run/docker.sock is bind-mounted
+# to this container in order for ACT to work.
+RUN apt -y install docker git
+
+# Install Act.
+RUN go install "github.com/nektos/act@v0.2.25"
+
+# Copy our documentation into the image.
+COPY . /app
+WORKDIR /app
+
+ENTRYPOINT [ "act", "-P", "ubuntu-latest=ghcr.io/catthehacker/ubuntu:act-latest" ]

--- a/TESTING.md
+++ b/TESTING.md
@@ -7,6 +7,17 @@ As this repository is publicly hosted on GitHub, we utilized GitHub Actions to p
 - Link Validity
 - Orphaned Content
 
+## Testing Locally
+
+We recommend running your tests locally before submitting any pull requests.
+Install Docker Compose then run this command to do so:
+
+```sh
+docker-compose run --rm tests
+```
+
+This will execute all of the tests that are executed by GitHub Actions.
+
 ## Spelling
 
 This check utilizes the [cspell](https://github.com/streetsidesoftware/cspell) spell checker for code. This utility was chosen as it has wide platform support and will accommodate both CI/CD testing as well as IDE-based inline checking during authorship. It is currently utilizing an `en` and `en-US` dictionary, but custom dictionary words may be added to the [wordlist.txt](./wordlist.txt) file. Any word appended to this file will automatically be cleared for spelling.

--- a/TESTING.md
+++ b/TESTING.md
@@ -7,17 +7,6 @@ As this repository is publicly hosted on GitHub, we utilized GitHub Actions to p
 - Link Validity
 - Orphaned Content
 
-## Testing Locally
-
-We recommend running your tests locally before submitting any pull requests.
-Install Docker Compose then run this command to do so:
-
-```sh
-docker-compose run --rm tests
-```
-
-This will execute all of the tests that are executed by GitHub Actions.
-
 ## Spelling
 
 This check utilizes the [cspell](https://github.com/streetsidesoftware/cspell) spell checker for code. This utility was chosen as it has wide platform support and will accommodate both CI/CD testing as well as IDE-based inline checking during authorship. It is currently utilizing an `en` and `en-US` dictionary, but custom dictionary words may be added to the [wordlist.txt](./wordlist.txt) file. Any word appended to this file will automatically be cleared for spelling.
@@ -70,3 +59,13 @@ Alternatively, you may execute specific parts of the test suite with:
 ```bash
 $ act -j <spell-check|link-check|orphaned-content-check>
 ```
+
+You can also use Docker Compose to run these tests if you wish to not install `act`.
+Run this command to do so after installing Docker Compose:
+
+```sh
+docker-compose run --rm tests
+```
+
+This will execute all of the tests that are executed by GitHub Actions.
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '2.2'
+services:
+  tests:
+    build:
+      context: .
+    privileged: true
+    volumes:
+      - $PWD:/app
+      - /var/run/docker.sock:/var/run/docker.sock
+    working_dir: /app


### PR DESCRIPTION
This pull request adds a Docker Compose service that makes it easy for
contributors to locally test their contributions before entering the
CI/CD process.

See the changes proposed in `CONTRIBUTING.md` and `TESTING.md` for more
information on how to use this service.

Signed-off-by: Carlos Nunez <ncarlos@vmware.com>
