### PR TITLE
Ignore links from avinetworks.com

### DIFF
--- a/link-check.json
+++ b/link-check.json
@@ -3,5 +3,6 @@
   "retryOn429": true,
   "retryCount": 5,
   "fallbackRetryDelay": "30s",
-  "aliveStatusCodes": [200, 206]
+  "aliveStatusCodes": [200, 206],
+  "ignorePatterns": ["/avinetworks.com/"]
 }


### PR DESCRIPTION
Our GitHub runners are currently getting connection resets from this
domain, and it is causing tests to fail. Ignoring this domain until the
connection resets are resolved.

Signed-off-by: Craig Tracey <craigtracey@gmail.com>