### PR TITLE
Update reference architecture for Tanzu Application Platform 1.1

### DIFF
--- a/src/deployment-guides/tko-on-azure.md
+++ b/src/deployment-guides/tko-on-azure.md
@@ -86,7 +86,7 @@ Based on the recommended minimum virtual machine size of D2s_v3, the following m
 Ensure that you increase the quotas if you make changes to the basic configuration of the clusters.
 
 ### ARM Template Deployment
-####Deploy ARM Template
+#### Deploy ARM Template
 There are multiple methods to deploy an ARM template on Azure. If you are experienced with Azure, you can deploy the ARM template in a method that is comfortable to you.
 
 Otherwise, you can use the example Azure CLI commands locally or in Azure Cloud Shell. If you prefer to use Azure PowerShell, use the example command for Azure PowerShell.

--- a/src/reference-designs/tap-architecture-planning.md
+++ b/src/reference-designs/tap-architecture-planning.md
@@ -1,10 +1,10 @@
 ## Architecture Overview
-This architecture gives you a path to creating a production deployment of Tanzu Application Platform 1.0. However, do not feel constrained to follow this exact path if your specific use cases warrant a different architecture.
+This architecture gives you a path to creating a production deployment of Tanzu Application Platform 1.1. However, do not feel constrained to follow this exact path if your specific use cases warrant a different architecture.
 
 Design decisions enumerated in this document exemplify the main design issues you will encounter in planning your Tanzu Application Platform environment and the rationale behind a chosen solution path. Understanding these decisions can help provide a rationale for any necessary deviation from this architecture.
 
 ![](img/tap-architecture-planning/overview.jpg)
-<!-- https://lucid.app/lucidchart/313468a7-da40-4872-9075-cd37224c5e2f/ -->
+<!-- https://lucid.app/lucidchart/313468a7-da40-4872-9075-cd37224c5e2f/edit -->
 
 ### Cluster Layout
 For production deployments, VMware recommends two fully independent instances of Tanzu Application Platform. One instance for operators to conduct their own reliability tests, and the other instance hosts development, test, QA, and production environments isolated by separate clusters.
@@ -32,42 +32,29 @@ The Kubernetes Build Cluster will see bursty workloads as each build or series o
 * Spread across three Availability Zones (AZs) for high availability
 * Tanzu Service Mesh (TSM) is not installed or is restricted namespaces that are not Tanzu Application Platform
 
-The Build Cluster includes the following packages:
+The Build Cluster includes the following packages (exact list may differ based on supply chain choice):
 ```
-build.appliveview.tanzu.vmware.com
 buildservice.tanzu.vmware.com
 cartographer.tanzu.vmware.com
 cert-manager.tanzu.vmware.com
 contour.tanzu.vmware.com
 controller.conventions.apps.tanzu.vmware.com
 controller.source.apps.tanzu.vmware.com
+conventions.appliveview.tanzu.vmware.com
 fluxcd.source.controller.tanzu.vmware.com
 grype.scanning.apps.tanzu.vmware.com
-image-policy-webhook.signing.apps.tanzu.vmware.com
-metadata-store.apps.tanzu.vmware.com
-ootb-supply-chain-basic.tanzu.vmware.com
+ootb-supply-chain-testing-scanning.tanzu.vmware.com
 ootb-templates.tanzu.vmware.com
 scanning.apps.tanzu.vmware.com
 spring-boot-conventions.tanzu.vmware.com
+tap-auth.tanzu.vmware.com
 tap-telemetry.tanzu.vmware.com
 tap.tanzu.vmware.com
 tekton.tanzu.vmware.com
 ```
 To install a Build Cluster, use the following package definition:
 ```yaml
-profile: full
-excluded_packages:
- - accelerator.apps.tanzu.vmware.com
- - run.appliveview.tanzu.vmware.com
- - api-portal.tanzu.vmware.com
- - cnrs.tanzu.vmware.com
- - ootb-delivery-basic.tanzu.vmware.com
- - developer-conventions.tanzu.vmware.com
- - learningcenter.tanzu.vmware.com
- - workshops.learningcenter.tanzu.vmware.com
- - services-toolkit.tanzu.vmware.com
- - service-bindings.labs.vmware.com
- - tap-gui.tanzu.vmware.com
+profile: build
  ```
 ### Run Cluster Requirements
 
@@ -91,39 +78,23 @@ The Run Cluster includes the following packages:
 cartographer.tanzu.vmware.com
 cert-manager.tanzu.vmware.com
 cnrs.tanzu.vmware.com
+connector.appliveview.tanzu.vmware.com
 contour.tanzu.vmware.com
 controller.source.apps.tanzu.vmware.com
 fluxcd.source.controller.tanzu.vmware.com
 image-policy-webhook.signing.apps.tanzu.vmware.com
 ootb-delivery-basic.tanzu.vmware.com
 ootb-templates.tanzu.vmware.com
-run.appliveview.tanzu.vmware.com
 service-bindings.labs.vmware.com
 services-toolkit.tanzu.vmware.com
+tap-auth.tanzu.vmware.com
 tap-telemetry.tanzu.vmware.com
 tap.tanzu.vmware.com
-tekton.tanzu.vmware.com
 ```
+
 To install a Run Cluster, use the following package definition:
 ```yaml
-profile: full
-excluded_packages:
- - accelerator.apps.tanzu.vmware.com
- - api-portal.tanzu.vmware.com
- - build.appliveview.tanzu.vmware.com
- - buildservice.tanzu.vmware.com
- - controller.conventions.apps.tanzu.vmware.com
- - developer-conventions.tanzu.vmware.com
- - grype.scanning.apps.tanzu.vmware.com
- - learningcenter.tanzu.vmware.com
- - metadata-store.apps.tanzu.vmware.com
- - ootb-supply-chain-basic.tanzu.vmware.com
- - ootb-supply-chain-testing.tanzu.vmware.com
- - ootb-supply-chain-testing-scanning.tanzu.vmware.com
- - scanning.apps.tanzu.vmware.com
- - spring-boot-conventions.tanzu.vmware.com
- - tap-gui.tanzu.vmware.com
- - workshops.learningcenter.tanzu.vmware.com
+profile: run
 ```
 ### View Cluster Requirements
 The View Cluster is designed to run the web applications for Tanzu Application Platform. specifically, Tanzu Learning Center, Tanzu Application Portal GUI, and Tanzu API Portal.
@@ -147,12 +118,14 @@ The View Cluster includes the following packages:
 ```
 accelerator.apps.tanzu.vmware.com
 api-portal.tanzu.vmware.com
+backend.appliveview.tanzu.vmware.com
 cert-manager.tanzu.vmware.com
 contour.tanzu.vmware.com
 controller.source.apps.tanzu.vmware.com
 fluxcd.source.controller.tanzu.vmware.com
-image-policy-webhook.signing.apps.tanzu.vmware.com
 learningcenter.tanzu.vmware.com
+metadata-store.apps.tanzu.vmware.com
+tap-auth.tanzu.vmware.com
 tap-gui.tanzu.vmware.com
 tap-telemetry.tanzu.vmware.com
 tap.tanzu.vmware.com
@@ -161,30 +134,7 @@ workshops.learningcenter.tanzu.vmware.com
 
 To install a View Cluster, use the following package definition:
 ```yaml
-profile: full
-excluded_packages:
- - run.appliveview.tanzu.vmware.com
- - cnrs.tanzu.vmware.com
- - ootb-delivery-basic.tanzu.vmware.com
- - developer-conventions.tanzu.vmware.com
- - image-policy-webhook.signing.apps.tanzu.vmware.com
- - services-toolkit.tanzu.vmware.com
- - service-bindings.labs.vmware.com
- - build.appliveview.tanzu.vmware.com
- - buildservice.tanzu.vmware.com
- - controller.conventions.apps.tanzu.vmware.com
- - developer-conventions.tanzu.vmware.com
- - grype.scanning.apps.tanzu.vmware.com
- - metadata-store.apps.tanzu.vmware.com
- - ootb-supply-chain-basic.tanzu.vmware.com
- - ootb-supply-chain-testing.tanzu.vmware.com
- - ootb-supply-chain-testing-scanning.tanzu.vmware.com
- - scanning.apps.tanzu.vmware.com
- - spring-boot-conventions.tanzu.vmware.com
- - ootb-templates.tanzu.vmware.com
- - tekton.tanzu.vmware.com
- - image-policy-webhook.signing.apps.tanzu.vmware.com
- - cartographer.tanzu.vmware.com
+profile: view
  ```
 ### Iterate Cluster Requirements
 The Iterate Cluster is for "inner loop" development iteration. Developers connect to the Iterate Cluster via their IDE to rapidly iterate on new software features. The Iterate Cluster operates distinctly from the outer loop infrastructure. Each developer should be given their own namespace within the Iterate Cluster during their platform onboarding.
@@ -205,18 +155,19 @@ The Iterate Cluster is for "inner loop" development iteration. Developers connec
 
 The Iterate Cluster includes the following packages:
 ```
-build.appliveview.tanzu.vmware.com
+backend.appliveview.tanzu.vmware.com
 buildservice.tanzu.vmware.com
 cartographer.tanzu.vmware.com
 cert-manager.tanzu.vmware.com
 cnrs.tanzu.vmware.com
+connector.appliveview.tanzu.vmware.com
 contour.tanzu.vmware.com
 controller.conventions.apps.tanzu.vmware.com
 controller.source.apps.tanzu.vmware.com
+conventions.appliveview.tanzu.vmware.com
 fluxcd.source.controller.tanzu.vmware.com
 grype.scanning.apps.tanzu.vmware.com
 image-policy-webhook.signing.apps.tanzu.vmware.com
-metadata-store.apps.tanzu.vmware.com
 ootb-delivery-basic.tanzu.vmware.com
 ootb-supply-chain-basic.tanzu.vmware.com
 ootb-templates.tanzu.vmware.com
@@ -225,6 +176,7 @@ scanning.apps.tanzu.vmware.com
 service-bindings.labs.vmware.com
 services-toolkit.tanzu.vmware.com
 spring-boot-conventions.tanzu.vmware.com
+tap-auth.tanzu.vmware.com
 tap-telemetry.tanzu.vmware.com
 tap.tanzu.vmware.com
 tekton.tanzu.vmware.com
@@ -232,16 +184,7 @@ tekton.tanzu.vmware.com
 
 To install a Iterate Cluster, use the following package definition:
 ```yaml
-profile: full
-excluded_packages:
- - accelerator.apps.tanzu.vmware.com
- - api-portal.tanzu.vmware.com
- - learningcenter.tanzu.vmware.com
- - metadata-store.apps.tanzu.vmware.com
- - ootb-supply-chain-testing.tanzu.vmware.com
- - ootb-supply-chain-testing-scanning.tanzu.vmware.com
- - tap-gui.tanzu.vmware.com
- - workshops.learningcenter.tanzu.vmware.com
+profile: iterate
 ```
 
 ## Tanzu Application Platform Upgrade Approach


### PR DESCRIPTION
Updates the TAP reference architecture for 1.1.

The two significant changes were the move to using the profiles available in 1.1 and the metadata store moving to the view cluster.