### PR TITLE
bugfix/vyata-dhcp-ip-allocation-issues

### DIFF
--- a/src/partials/vyatta.md
+++ b/src/partials/vyatta.md
@@ -346,3 +346,4 @@ save
 ```
 
 You can terminate your SSH session once finished.
+

--- a/src/partials/vyatta.md
+++ b/src/partials/vyatta.md
@@ -25,7 +25,7 @@ VM for your specific guide. For example, if you are using the
 appropriate for this lab:
 
 ```sh
-DEPLOYMENT_GUIDE="tko-on-sphere.md" # <-- change this
+DEPLOYMENT_GUIDE="tko-on-vsphere.md" # <-- change this
 VM_NAME="tkg-router"
 govc vm.create -annotation="TKG Networking Fabric" \
   -c=2 -iso=isos/vyos.iso \
@@ -39,7 +39,7 @@ do \
   if test "$(wc -c <<< "$name")" -gt 12; then name=$(head -c 10 <<< "$name"); fi; \
   vlan="$(awk -F '|' '{print $4}' <<< "$net" | tr -d ' ')"; \
   cidr="$(awk -F '|' '{print $5}' <<< "$net" | sed -E 's/ +//' | tr -d ' ' | tr '/' '_')"; \
-  cmd="govc host.portgroup.add -vswitch vSwitch0 ${name}-${cidr}-${vlan}"; \
+  cmd="govc host.portgroup.add -vswitch vSwitch0 -vlan=${vlan} ${name}-${cidr}-${vlan}"; \
   echo "--> $cmd"; \
   $cmd; \
   govc host.portgroup.change -allow-promiscuous=true -forged-transmits=true -mac-changes=true "${name}-${cidr}-${vlan}"; \

--- a/src/partials/vyatta.md
+++ b/src/partials/vyatta.md
@@ -25,7 +25,7 @@ VM for your specific guide. For example, if you are using the
 appropriate for this lab:
 
 ```sh
-DEPLOYMENT_GUIDE="tko-on-sphere.md" # <-- change this
+DEPLOYMENT_GUIDE="tko-on-vsphere.md" # <-- change this
 VM_NAME="tkg-router"
 govc vm.create -annotation="TKG Networking Fabric" \
   -c=2 -iso=isos/vyos.iso \
@@ -39,7 +39,7 @@ do \
   if test "$(wc -c <<< "$name")" -gt 12; then name=$(head -c 10 <<< "$name"); fi; \
   vlan="$(awk -F '|' '{print $4}' <<< "$net" | tr -d ' ')"; \
   cidr="$(awk -F '|' '{print $5}' <<< "$net" | sed -E 's/ +//' | tr -d ' ' | tr '/' '_')"; \
-  cmd="govc host.portgroup.add -vswitch vSwitch0 ${name}-${cidr}-${vlan}"; \
+  cmd="govc host.portgroup.add -vswitch vSwitch0 -vlan=${vlan} ${name}-${cidr}-${vlan}"; \
   echo "--> $cmd"; \
   $cmd; \
   govc host.portgroup.change -allow-promiscuous=true -forged-transmits=true -mac-changes=true "${name}-${cidr}-${vlan}"; \
@@ -346,3 +346,4 @@ save
 ```
 
 You can terminate your SSH session once finished.
+


### PR DESCRIPTION
Hi, @carlosonunez-vmw 
this PR address the issues on assigning IP to TKG VMs using the vyos DHCP server.
expected to get IP for each port group from the expected dhcp network on vyos vm. but assigned all IPs from single dhcp-server network. and  wondering how the assignment mapps among vswitch port_group and  vyos dhcp shared-network-name list.
expected:
```
1) Test VM with portgroup: "tkg_mgmt_pg-192.168.40.1"          should get 192.168.40.200 from vyos DHCP pool "tkg-mgmt-network"
2) Test VM with portgroup: "tkg_workload_pg-192.168.60.1"      should get 192.168.60.200 from vyos DHCP pool tkg-workload-network
```
actual result
```
1) Test VM with portgroup: "tkg_mgmt_pg-192.168.40.1"          got 192.168.40.200 from vyos DHCP pool "tkg-mgmt-network"
2) Test VM with portgroup: "tkg_workload_pg-192.168.60.1"      got 192.168.40.201 from vyos DHCP pool tkg-mgmt-network
```

solution

adding vlan on portgroup
```
add vlan on portgroup
govc host.portgroup.add -vswitch vSwitch0 -vlan=10 "nsx_alb_management_pg-192.168.10.1"
govc host.portgroup.add -vswitch vSwitch0 -vlan=40 "tkg_mgmt_pg-192.168.40.1"
govc host.portgroup.add -vswitch vSwitch0 -vlan=50 "tkg_mgmt_vip_pg-192.168.50.1"
govc host.portgroup.add -vswitch vSwitch0 -vlan=80 "tkg_cluster_vip_pg-192.168.80.1"
govc host.portgroup.add -vswitch vSwitch0 -vlan=70 "tkg_workload_vip_pg-192.168.70.1"
govc host.portgroup.add -vswitch vSwitch0 -vlan=60 "tkg_workload_pg-192.168.60.1"
```