### PR TITLE
Reintroduce avi link checks

### DIFF
--- a/link-check.json
+++ b/link-check.json
@@ -3,6 +3,5 @@
   "retryOn429": true,
   "retryCount": 5,
   "fallbackRetryDelay": "30s",
-  "aliveStatusCodes": [200, 206],
-  "ignorePatterns": ["/avinetworks.com/"]
+  "aliveStatusCodes": [200, 206]
 }


### PR DESCRIPTION
We had removed avinetworks as it had been failing supriously.
Reintroduce those checks.

Signed-off-by: Craig Tracey <craigtracey@gmail.com>